### PR TITLE
fix: handle INVALID_PASSWORD API error gracefully

### DIFF
--- a/shared/src/main/java/net/leaderos/shared/enums/AuthResponse.java
+++ b/shared/src/main/java/net/leaderos/shared/enums/AuthResponse.java
@@ -10,6 +10,7 @@ public enum AuthResponse {
     // Login statuses
     USER_NOT_FOUND,
     WRONG_PASSWORD,
+    INVALID_PASSWORD,
 
     // Register statuses
     USERNAME_ALREADY_EXIST,

--- a/shared/src/main/java/net/leaderos/shared/enums/ErrorCode.java
+++ b/shared/src/main/java/net/leaderos/shared/enums/ErrorCode.java
@@ -5,6 +5,7 @@ public enum ErrorCode {
     // login
     USER_NOT_FOUND,
     WRONG_PASSWORD,
+    INVALID_PASSWORD,
 
     // register
     USERNAME_ALREADY_EXIST,
@@ -18,6 +19,8 @@ public enum ErrorCode {
     LOGIN_REQUIRED,
     HAS_SESSION,
 
-    ;
+    // generic errors
+    UNKNOWN_ERROR,
 
+    ;
 }

--- a/shared/src/main/java/net/leaderos/shared/model/Request.java
+++ b/shared/src/main/java/net/leaderos/shared/model/Request.java
@@ -96,6 +96,24 @@ public abstract class Request {
             Shared.getDebugAPI().send(e.getMessage(), true);
             Shared.getDebugAPI().send(responseString, true);
             e.printStackTrace();
+            
+            // Create a fallback response to prevent null pointer exceptions
+            try {
+                JSONObject fallbackObj = new JSONObject();
+                fallbackObj.put("error", "PARSE_ERROR");
+                fallbackObj.put("message", "Failed to parse response: " + e.getMessage());
+                this.response = new Response(responseCode, false, fallbackObj, ErrorCode.UNKNOWN_ERROR);
+            } catch (Exception fallbackException) {
+                // If even the fallback fails, create a minimal response
+                try {
+                    JSONObject minimalObj = new JSONObject();
+                    minimalObj.put("error", "CRITICAL_ERROR");
+                    this.response = new Response(responseCode, false, minimalObj, ErrorCode.UNKNOWN_ERROR);
+                } catch (Exception criticalException) {
+                    // Last resort - this should never happen
+                    criticalException.printStackTrace();
+                }
+            }
         }
         connection.disconnect();
     }


### PR DESCRIPTION
- Add INVALID_PASSWORD to ErrorCode enum
- Add INVALID_PASSWORD to AuthResponse enum
- Improve error handling in AuthUtil with null checks
- Add fallback error responses to prevent crashes
- Map API error strings to enum values robustly

Fixes JSON parsing crashes when API returns non-enum error codes like 'INVALID_PASSWORD' instead of exact enum matches.

Resolves: Plugin crashes on authentication errors

**Note**: This is just a friendly contribution to help improve the plugin! 
Feel free to use, modify, or ignore these changes as you see fit. 
Happy to help make the plugin more robust! 🚀